### PR TITLE
Ensure latex package filegroups are publicly visible

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -1,4 +1,4 @@
-load(":packages.bzl", "latex_package")
+load(":packages.bzl", "latex_package", "public_filegroup")
 
 # Externally usable library targets.
 
@@ -452,7 +452,7 @@ latex_package(
 
 # Internal library targets.
 
-filegroup(
+public_filegroup(
     name = "amsfonts",
     srcs = [
         "@texlive_texmf__texmf-dist__fonts__tfm__public__amsfonts__cmextra",
@@ -460,17 +460,17 @@ filegroup(
     ],
 )
 
-filegroup(
+public_filegroup(
     name = "amsmath",
     srcs = ["@texlive_texmf__texmf-dist__tex__latex__amsmath"],
 )
 
-filegroup(
+public_filegroup(
     name = "babel",
     srcs = ["@texlive_texmf__texmf-dist__tex__generic__babel"],
 )
 
-filegroup(
+public_filegroup(
     name = "bezos",
     srcs = [
         ":keyval",
@@ -479,18 +479,18 @@ filegroup(
     ],
 )
 
-filegroup(
+public_filegroup(
     name = "ec",
     srcs = ["@texlive_texmf__texmf-dist__fonts__tfm__jknappen__ec"],
 )
 
-filegroup(
+public_filegroup(
     name = "genmisc",
     srcs = ["@texlive_texmf__texmf-dist__tex__generic__genmisc"],
 )
 
 # These packages have a cyclic dependency on each other.
-filegroup(
+public_filegroup(
     name = "graphics_oberdiek",
     srcs = [
         ":soul",
@@ -502,22 +502,22 @@ filegroup(
     ],
 )
 
-filegroup(
+public_filegroup(
     name = "l3kernel",
     srcs = ["@texlive_texmf__texmf-dist__tex__latex__l3kernel"],
 )
 
-filegroup(
+public_filegroup(
     name = "latxfont",
     srcs = ["@texlive_texmf__texmf-dist__fonts__type1__public__amsfonts__latxfont"],
 )
 
-filegroup(
+public_filegroup(
     name = "ms",
     srcs = ["@texlive_texmf__texmf-dist__tex__latex__ms"],
 )
 
-filegroup(
+public_filegroup(
     name = "pgf",
     srcs = [
         ":everyshi",
@@ -539,7 +539,7 @@ filegroup(
     ],
 )
 
-filegroup(
+public_filegroup(
     name = "psnfss",
     srcs = [
         ":keyval",
@@ -547,7 +547,7 @@ filegroup(
     ],
 )
 
-filegroup(
+public_filegroup(
     name = "tools",
     srcs = ["@texlive_texmf__texmf-dist__tex__latex__tools"],
 )

--- a/packages/packages.bzl
+++ b/packages/packages.bzl
@@ -1,10 +1,16 @@
 load("//:latex.bzl", "latex_document")
 
-def latex_package(name, srcs = []):
+def public_filegroup(name, srcs = []):
     native.filegroup(
         name = name,
         srcs = srcs,
         visibility = ["//visibility:public"],
+    )
+
+def latex_package(name, srcs = []):
+    public_filegroup(
+        name = name,
+        srcs = srcs
     )
 
     latex_document(


### PR DESCRIPTION
Thanks for contributing these rules - I was able to get an old document building pretty quickly. While doing so, I did find an issue that manifests like this:

- `@bazel_latex//packages:amssymb` works just fine
- `@bazel_latex//packages:amsmath` does not work as it is not publicly visible, had to resort to `@texlive_texmf__texmf-dist__tex__latex__amsmath`

The above issue is due to `latex_package()` declaring its `filegroup()` calls with `//visibility:public` while the `filegroup()` calls in `packages/BUILD.bazel` use the default private visibility.

I've added a utility function in `packages.bzl` that sets visibility to public and changed all calls in `packages/BUILD.bazel` to use it.