### PR TITLE
Define package upquote

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,6 @@
 Copyright 2018 Prodrive Technologies B.V.
+Copyright 2018 Google LLC.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -481,6 +481,11 @@ latex_package(
 )
 
 latex_package(
+    name = "upquote",
+    srcs = ["@texlive_texmf__texmf-dist__tex__latex__upquote"],
+)
+
+latex_package(
     name = "url",
     srcs = ["@texlive_texmf__texmf-dist__tex__latex__url"],
 )

--- a/packages/upquote_test.tex
+++ b/packages/upquote_test.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{upquote}
+\begin{document}
+\begin{verbatim}
+foo = 'bar'
+\end{verbatim}
+\end{document}


### PR DESCRIPTION

This backage changes the style of quotes in "verbatim" sections.
https://ctan.org/pkg/upquote

For instance, for
```
foo = 'bar'
```

By default, they produce:

    foo = ’bar’

With upquote, they the quotes remain "up" style:

    foo = 'bar'
