### PR TITLE
exam: add exam package

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -261,6 +261,12 @@ latex_package(
 )
 
 latex_package(
+    name = "exam",
+    srcs = ["@texlive_texmf__texmf-dist__tex__latex__exam"],
+    tests = ["exam_test.tex"],
+)
+
+latex_package(
     name = "expl3",
     srcs = [":l3kernel"],
     tests = ["expl3_test.tex"],

--- a/packages/exam_test.tex
+++ b/packages/exam_test.tex
@@ -1,0 +1,5 @@
+\documentclass{exam}
+
+\begin{document}
+Hello, world!
+\end{document}


### PR DESCRIPTION
**Description**
This change adds the ability for those using`bazel-latex` to pull in the `exam` document class.

**Testing done**
Ran `bazel run packages:exam_exam_test.tex_view` and ensured that the document is able to compile and display properly.