### PR TITLE
multicol: add multicol package

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -626,6 +626,12 @@ latex_package(
 )
 
 latex_package(
+    name = "multicol",
+    srcs = ["@texlive_texmf__texmf-dist__tex__latex__tools"],
+    tests = ["multicol_test.tex"],
+)
+
+latex_package(
     name = "nth",
     srcs = [":genmisc"],
     tests = ["nth_test.tex"],

--- a/packages/multicol_test.tex
+++ b/packages/multicol_test.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{multicol}
+
+\begin{document}
+\begin{multicols}{3}
+\begin{itemize}
+  \item This
+  \item is
+  \item a
+  \item Test
+\end{itemize}
+\end{multicols}
+\end{document}


### PR DESCRIPTION
**Description**
This change adds the ability for those using`bazel-latex` to pull in the `multicol` package.

**Testing done**
Ran `bazel run packages:multicol_multicol_test.tex_view` and ensured that the document is able to compile and display properly.