### PR TITLE
drawstack: add drawstack package

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -212,6 +212,15 @@ latex_package(
 )
 
 latex_package(
+    name = "drawstack",
+    srcs = [
+        ":tikz",
+        "@texlive_texmf__texmf-dist__tex__latex__drawstack",
+    ],
+    tests = ["drawstack_test.tex"],
+)
+
+latex_package(
     name = "enumerate",
     srcs = [":tools"],
     tests = ["enumerate_test.tex"],

--- a/packages/drawstack_test.tex
+++ b/packages/drawstack_test.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+\usepackage{drawstack}
+
+\begin{document}
+\begin{drawstack}
+  \cell{This is a test}
+\end{drawstack}
+\end{document}


### PR DESCRIPTION
**Description**
This change adds the ability for those using`bazel-latex` to pull in the `drawstack` package.

**Testing done**
Ran `bazel run packages:drawstack_drawstack_test.tex_view` and ensured that the document is able to compile and display properly.