### PR TITLE
run_lualatex: ensure that latexrun_file is executable before attempting to run it

### DIFF
--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -3,6 +3,7 @@
 import glob
 import os
 import shutil
+import stat
 import subprocess
 import sys
 
@@ -50,6 +51,9 @@ shutil.copy(kpsewhich_file, "bin/kpsewhich")
 shutil.copy(luatex_file, "bin/lualatex")
 os.link("bin/lualatex", "bin/luatex")
 shutil.copy("texmf/texmf-dist/scripts/texlive/fmtutil.pl", "bin/mktexfmt")
+
+st = os.stat(latexrun_file)
+os.chmod(latexrun_file, st.st_mode | stat.S_IEXEC)
 
 return_code = subprocess.call(
     args=[


### PR DESCRIPTION
The bazel latex build was failing because the `latexrun_file` was not executable, resulting in a traceback like this:

```
Traceback (most recent call last):
  File "external/bazel_latex/run_lualatex.py", line 62, in <module>
    env=env,
  File "/usr/lib64/python2.7/subprocess.py", line 172, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib64/python2.7/subprocess.py", line 394, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1047, in _execute_child
    raise child_exception
OSError: [Errno 13] Permission denied
Target //intro_cpp:syllabus failed to build
```

The `latexrun_file` is not executable and expects that `python3` be put in front it, though it has a `#!/usr/bin/env python3` shebang at the top of the file. Instead of assuming that `python3` is in the user's path and updating the `subprocess.call(...)` command, this change updates the `run_lualatex.py` file to ensure that the `latexrun_file` is executable before it is run. The shebang with `/usr/bin/env` will take care of the rest.