### PR TITLE
run_lualatex: fix running a non-executable python file #23

### DIFF
--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -53,6 +53,7 @@ shutil.copy("texmf/texmf-dist/scripts/texlive/fmtutil.pl", "bin/mktexfmt")
 
 return_code = subprocess.call(
     args=[
+        "python3",
         latexrun_file,
         "--latex-args=-jobname=" + job_name,
         "--latex-cmd=lualatex",


### PR DESCRIPTION
This change appends a `python3` command prefix in the `subprocess.call(...)` to ensure that the `latexrun_file` will be executed. For some reason, it is not executable and we need to make sure that it either is or somehow otherwise finds the `python3` interpreter.