### PR TITLE
tikz-qtree: add tikz-qtree package

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -821,8 +821,8 @@ latex_package(
 latex_package(
     name = "tikz-qtree",
     srcs = [
-        "@texlive_texmf__texmf-dist__tex__latex__tikz-qtree",
         ":pgf",
+        "@texlive_texmf__texmf-dist__tex__latex__tikz-qtree",
     ],
     tests = ["tikz-qtree_test.tex"],
 )

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -819,6 +819,15 @@ latex_package(
 )
 
 latex_package(
+    name = "tikz-qtree",
+    srcs = [
+        "@texlive_texmf__texmf-dist__tex__latex__tikz-qtree",
+        ":pgf",
+    ],
+    tests = ["tikz-qtree_test.tex"],
+)
+
+latex_package(
     name = "titlesec",
     srcs = ["@texlive_texmf__texmf-dist__tex__latex__titlesec"],
     tests = ["titlesec_test.tex"],

--- a/packages/tikz-qtree_test.tex
+++ b/packages/tikz-qtree_test.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\usepackage{tikz}
+\usepackage{tikz-qtree}
+\begin{document}
+\Tree [.S [.NP [.Det the ] [.N cat ] ]
+          [.VP [.V sat ]
+                [.PP [.P on ]
+                     [.NP [.Det the ] [.N mat ] ] ] ] ]
+\end{document}


### PR DESCRIPTION
**Description**
This change adds the ability for those using`bazel-latex` to pull in the `tikz-qtree` package.

**Testing done**
Ran `bazel run packages:tikz-qtree_tikz-qtree_test.tex_view` and ensured that the document is able to compile properly.