### PR TITLE
Feature/adding no output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ It can be viewed using your system's PDF viewer by running:
 bazel run :my_report_view
 ```
 
-If no ouput from the PDF viewer is needed you can view the PDF by by running:
+If you want to get the output from the PDF viewer you can run:
 
 ```
-bazel run :my_report_view_no_ouput
+bazel run :my_report_view_output
 ```
 
 # Using packages

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ bazel run :my_report_view
 If no ouput from the PDF viewer is needed you can view the PDF by by running:
 
 ```
-bazel run :my_report_view_on_ouput
+bazel run :my_report_view_no_ouput
 ```
 
 # Using packages

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ It can be viewed using your system's PDF viewer by running:
 bazel run :my_report_view
 ```
 
+If no ouput from the PDF viewer is needed you can view the PDF by by running:
+
+```
+bazel run :my_report_view_on_ouput
+```
+
 # Using packages
 
 By default, `latex_document()` only provides a version of TeXLive that

--- a/latex.bzl
+++ b/latex.bzl
@@ -47,14 +47,14 @@ def latex_document(name, main, srcs = []):
 
     # Convenience rule for viewing PDFs.
     native.sh_binary(
-        name = name + "_view",
+        name = name + "_view_output",
         srcs = ["@bazel_latex//:view_pdf.sh"],
         data = [name + ".pdf"],
     )
-  
+
     # Convenience rule for viewing PDFs.
     native.sh_binary(
-        name = name + "_view_no_output",
+        name = name + "_view",
         srcs = ["@bazel_latex//:view_pdf.sh"],
         data = [name + ".pdf"],
         args = ["None"],

--- a/latex.bzl
+++ b/latex.bzl
@@ -51,3 +51,11 @@ def latex_document(name, main, srcs = []):
         srcs = ["@bazel_latex//:view_pdf.sh"],
         data = [name + ".pdf"],
     )
+  
+    # Convenience rule for viewing PDFs.
+    native.sh_binary(
+        name = name + "_view_no_output",
+        srcs = ["@bazel_latex//:view_pdf.sh"],
+        data = [name + ".pdf"],
+        args = ["None"],
+    )

--- a/view_pdf.sh
+++ b/view_pdf.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 filename="$(find . -name '*.pdf')"
 
-
 if type xdg-open > /dev/null 2>&1; then
     # X11-based systems (Linux, BSD).
-    if [ $1 == "None" ]; then   
+    
+    if [ $1 = "None" ] ; then   
         exec xdg-open "${filename}" 2>/dev/null &
     else
         exec xdg-open "${filename}" &

--- a/view_pdf.sh
+++ b/view_pdf.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 filename="$(find . -name '*.pdf')"
+
+
 if type xdg-open > /dev/null 2>&1; then
     # X11-based systems (Linux, BSD).
-    exec xdg-open "${filename}" &
+    if [ $1 == "None" ]; then   
+        exec xdg-open "${filename}" 2>/dev/null &
+    else
+        exec xdg-open "${filename}" &
+    fi
+
 elif type open > /dev/null 2>&1; then
     # macOS.
     exec open "${filename}"


### PR DESCRIPTION
Using `<name>_view_no_output` all output of the `xdg-open` command will be redirected to `/dev/null`, so it will keep your terminal clean.