### PR TITLE
Support customization of python runtime

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,3 +64,9 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
+
+py_binary(
+    name = "run_lualatex",
+    srcs = ["run_lualatex.py"],
+    visibility = ["//visibility:public"],
+)

--- a/latex.bzl
+++ b/latex.bzl
@@ -2,10 +2,9 @@ def _latex_pdf_impl(ctx):
     toolchain = ctx.toolchains["@bazel_latex//:latex_toolchain_type"]
     ctx.actions.run(
         mnemonic = "LuaLatex",
-        executable = "python",
         use_default_shell_env = True,
+        executable = ctx.executable.tool,
         arguments = [
-            "external/bazel_latex/run_lualatex.py",
             toolchain.kpsewhich.files.to_list()[0].path,
             toolchain.luatex.files.to_list()[0].path,
             ctx.files._latexrun[0].path,
@@ -21,12 +20,18 @@ def _latex_pdf_impl(ctx):
             ],
         ),
         outputs = [ctx.outputs.out],
+        tools = [ctx.executable.tool],
     )
 
 _latex_pdf = rule(
     attrs = {
         "main": attr.label(allow_files = True),
         "srcs": attr.label_list(allow_files = True),
+        "tool": attr.label(
+            default = Label("//:run_lualatex"),
+            executable = True,
+            cfg = "host",
+        ),
         "_latexrun": attr.label(
             allow_files = True,
             default = "@bazel_latex_latexrun//:latexrun",

--- a/latex.bzl
+++ b/latex.bzl
@@ -37,12 +37,13 @@ _latex_pdf = rule(
     implementation = _latex_pdf_impl,
 )
 
-def latex_document(name, main, srcs = []):
+def latex_document(name, main, srcs = [], tags = []):
     # PDF generation.
     _latex_pdf(
         name = name,
         srcs = srcs + ["@bazel_latex//:core_dependencies"],
         main = main,
+        tags = tags,
     )
 
     # Convenience rule for viewing PDFs.
@@ -50,6 +51,7 @@ def latex_document(name, main, srcs = []):
         name = name + "_view_output",
         srcs = ["@bazel_latex//:view_pdf.sh"],
         data = [name + ".pdf"],
+        tags = tags,
     )
 
     # Convenience rule for viewing PDFs.
@@ -58,4 +60,5 @@ def latex_document(name, main, srcs = []):
         srcs = ["@bazel_latex//:view_pdf.sh"],
         data = [name + ".pdf"],
         args = ["None"],
+        tags = tags,
     )

--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -54,7 +54,7 @@ shutil.copy("texmf/texmf-dist/scripts/texlive/fmtutil.pl", "bin/mktexfmt")
 return_code = subprocess.call(
     args=[
         latexrun_file,
-        "--latex-args=-jobname=" + job_name,
+        "--latex-args=-shell-escape -jobname=" + job_name,
         "--latex-cmd=lualatex",
         "-Wall",
         main_file,


### PR DESCRIPTION
This is useful for say when you want to run python from a virtualenv or conda environment. This patch became necessary to be able to run packages that want to use `pygmentize`.