### PR TITLE
Fix packages tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,8 @@
 container:
     image: l.gcr.io/google/bazel:latest
 task:
-    name: Building the example
+    name: Build the example document
     build_script: bazel build //example:my_report
+task:
+    name: Build all package tests
+    build_script: bazel build //packages:all

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -167,7 +167,11 @@ latex_package(
 
 latex_package(
     name = "csquotes",
-    srcs = ["@texlive_texmf__texmf-dist__tex__latex__csquotes"],
+    srcs = [
+        ":etoolbox",
+        ":keyval",
+        "@texlive_texmf__texmf-dist__tex__latex__csquotes",
+    ],
     tests = ["csquotes_test.tex"],
 )
 

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -993,7 +993,7 @@ latex_package(
 
 latex_package(
     name = "xspace",
-    srcs = ["@texlive_texmf__texmf-dist__tex__latex__tools__xspace"],
+    srcs = ["@texlive_texmf__texmf-dist__tex__latex__tools"],
     tests = ["xspace_test.tex"],
 )
 


### PR DESCRIPTION
`bazel build //packages:all` failed for two tests:
- `xpace`, because **xspace.sty** is now directly in the tools folder,
- `csquotes`, because **etoolbox.sty** and **keyval.sty** are required.