### PR TITLE
Update for Bazel 3.5

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,10 @@ exports_files([
     "view_pdf.sh",
 ])
 
+toolchain_type(name = "latex_toolchain_type")
+
 latex_toolchain(
+    name = "latex_toolchain_amd64-freebsd",
     exec_compatible_with = [
         "@bazel_tools//platforms:freebsd",
         "@bazel_tools//platforms:x86_64",
@@ -14,6 +17,7 @@ latex_toolchain(
 )
 
 latex_toolchain(
+    name = "latex_toolchain_x86_64-darwin",
     exec_compatible_with = [
         "@bazel_tools//platforms:osx",
         "@bazel_tools//platforms:x86_64",
@@ -22,6 +26,7 @@ latex_toolchain(
 )
 
 latex_toolchain(
+    name = "latex_toolchain_x86_64-linux",
     exec_compatible_with = [
         "@bazel_tools//platforms:linux",
         "@bazel_tools//platforms:x86_64",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "bazel_latex")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "bazel_toolchains",
     sha256 = "4329663fe6c523425ad4d3c989a8ac026b04e1acedeceb56aa4b190fa7f3973c",
@@ -13,3 +15,9 @@ http_archive(
 load("@bazel_latex//:repositories.bzl", "latex_repositories")
 
 latex_repositories()
+
+register_toolchains(
+    "@bazel_latex//:latex_toolchain_amd64-freebsd",
+    "@bazel_latex//:latex_toolchain_x86_64-darwin",
+    "@bazel_latex//:latex_toolchain_x86_64-linux",
+)

--- a/latex.bzl
+++ b/latex.bzl
@@ -5,7 +5,7 @@ def _latex_pdf_impl(ctx):
         executable = "python",
         use_default_shell_env = True,
         arguments = [
-            "external/bazel_latex/run_lualatex.py",
+            "run_lualatex.py",
             toolchain.kpsewhich.files.to_list()[0].path,
             toolchain.luatex.files.to_list()[0].path,
             ctx.files._latexrun[0].path,
@@ -13,8 +13,7 @@ def _latex_pdf_impl(ctx):
             ctx.files.main[0].path,
             ctx.outputs.out.path,
         ],
-        inputs = toolchain.kpsewhich.files + toolchain.luatex.files +
-                 ctx.files._latexrun + ctx.files.main + ctx.files.srcs,
+        inputs = depset(direct = ctx.files._latexrun + ctx.files.main + ctx.files.srcs, transitive = [toolchain.kpsewhich.files, toolchain.luatex.files]),
         outputs = [ctx.outputs.out],
     )
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -5474,9 +5474,3 @@ filegroup(
         strip_prefix = "latexrun-38ff6ec2815654513c91f64bdf2a5760c85da26e",
         url = "https://github.com/aclements/latexrun/archive/38ff6ec2815654513c91f64bdf2a5760c85da26e.tar.gz",
     )
-
-    native.register_toolchains(
-        "@bazel_latex//:latex_toolchain_amd64-freebsd",
-        "@bazel_latex//:latex_toolchain_x86_64-darwin",
-        "@bazel_latex//:latex_toolchain_x86_64-linux",
-    )

--- a/toolchain.bzl
+++ b/toolchain.bzl
@@ -1,3 +1,8 @@
+LatexInfo = provider(
+    doc = "Information about how to invoke LuaLatex",
+    fields = [],
+)
+
 def _latex_toolchain_info_impl(ctx):
     return [
         platform_common.ToolchainInfo(
@@ -22,17 +27,27 @@ _latex_toolchain_info = rule(
     implementation = _latex_toolchain_info_impl,
 )
 
-def latex_toolchain(platform, exec_compatible_with):
+def latex_toolchain(name, platform, exec_compatible_with):
+    """Defines a native toolchain for Latex
+
+    Args:
+        name: Name of the toolchain. Must end with the platform.
+        platform: Platform as identified by Texlive.
+        exec_compatible_with: Execution platform this toolchain is compatible with.
+    """
+    if not name.endswith(platform):
+        fail("Latex toolchain '${name}' should end with '${platform}'".format(name = name, platform = platform))
+    toolchain_info_name = name + "_info"
     _latex_toolchain_info(
-        name = "latex_toolchain_info_%s" % platform,
+        name = toolchain_info_name,
         kpsewhich = "@texlive_bin__%s//:kpsewhich" % platform,
         luatex = "@texlive_bin__%s//:luatex" % platform,
         visibility = ["//visibility:public"],
     )
 
     native.toolchain(
-        name = "latex_toolchain_%s" % platform,
+        name = name,
         exec_compatible_with = exec_compatible_with,
-        toolchain = ":latex_toolchain_info_%s" % platform,
+        toolchain = toolchain_info_name,
         toolchain_type = ":latex_toolchain_type",
     )


### PR DESCRIPTION
- Update syntax of inputs in _latex_pdf_impl rule
  `depset + depset` is not a valid syntax anymore
  https://github.com/bazelbuild/bazel/issues/10313
- Move tollchain_register in WORKSPACE
  native calls must be in the WORSPACE file, not in a Skylark file.
- Add `name` attribute to latex_toolchain
  Macros should have a name.