### PR TITLE
Add a way to provide dependencies to tests

### DIFF
--- a/packages/packages.bzl
+++ b/packages/packages.bzl
@@ -1,6 +1,6 @@
 load("//:latex.bzl", "latex_document")
 
-def latex_package(name, srcs = [], tests = []):
+def latex_package(name, srcs = [], tests = [], tests_deps = []):
     native.filegroup(
         name = name,
         srcs = srcs,
@@ -11,5 +11,5 @@ def latex_package(name, srcs = [], tests = []):
         latex_document(
             name = name + "_" + test,
             main = test,
-            srcs = [":" + name],
+            srcs = [":" + name] + tests_deps,
         )


### PR DESCRIPTION
This is needed for packages like `xtemplate` where a minimum test case depends on more packages than the package itself. I'm not familiar with `xtemplate` (nor LaTeX as a whole) to write a minimum test case myself - there might be a way to do that without any other dependency - I'm just trying to add it because it's a transitive dependency for other packages I need.

Another option would be to add the dependencies directly to the package itself, as they're likely to be used by consuming targets anyway. I don't have a strong opinion on that, I'd be happy either way.