### PR TITLE
Support custom dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ And add the following `load()` directive to your `BUILD` files:
 load("@bazel_latex//:latex.bzl", "latex_document")
 ```
 
-You can then use `latex_document()` to declare documents that need to be
-built. Commonly reused sources (e.g., templates) can be placed in
-[`filegroup()`](https://docs.bazel.build/versions/master/be/general.html#filegroup)
-blocks, so that they don't need to be repeated.
+You can then use `latex_document()` in `BUILD` file to declare documents that need to be
+built.
 
 ```python
 latex_document(
@@ -52,11 +50,25 @@ latex_document(
         "chapters/*.tex",
         "figures/*",
         "references.bib",
-    ]) + [":company_style"],
+    ]) + ["//company_dir:company_style"],
     cmd_flags = ["--bibtex-cmd=biber"], % Optional
     main = "my_report.tex",
 )
+```
 
+Utilize `cmd_flags` to provide optional command line arguments, e.g. to run
+biber instead of bibtex.
+
+Commonly reused sources (e.g., templates) can be placed in
+[`filegroup()`](https://docs.bazel.build/versions/master/be/general.html#filegroup)
+blocks, so that they don't need to be repeated. Those `filegroup()` could
+be located not just in the single `BUILD` file, but in any of sub directories.
+For example, if you want to include company specific template files which are
+located in `//company_dir` directory as `company_style`, then declare them as
+like following in `company_dir/BUILD` file, and include the dependency, like
+`//company_dir:company_style`, in `latex_repositories`.
+
+```python
 filegroup(
     name = "company_style",
     srcs = glob([
@@ -64,12 +76,6 @@ filegroup(
     ]),
 )
 ```
-Utilize `cmd_flags` to provide optional command line arguments, e.g. to run 
-biber instead of bibtex.
-
-**Note:** as `lualatex` is effectively invoked as if within the root of the
-workspace, all imports of resources (e.g., images) must use the full
-path relative to the root.
 
 A PDF can be built by running:
 
@@ -111,7 +117,7 @@ Please open a pull request if additional bindings are needed.
 
 # Example
 
-An example is available in the corresponding folder. The example can 
+An example is available in the corresponding folder. The example can
 be executed by running:
 ```
 bazel run //example:my_report_view

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -7,6 +7,7 @@ latex_document(
     ]) + [
         "@bazel_latex//packages:biblatex",
         "references.bib",
+        "//example/example_class:example_class",
     ],
     cmd_flags = ["--bibtex-cmd=biber"],
     main = "my_report.tex",

--- a/example/example_class/BUILD
+++ b/example/example_class/BUILD
@@ -1,0 +1,8 @@
+filegroup(
+    name = "example_class",
+    srcs = [
+        "example_class.cls",
+        "@texlive_texmf__texmf-dist__tex__latex__xcolor",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/example/example_class/example_class.cls
+++ b/example/example_class/example_class.cls
@@ -1,0 +1,5 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{exampleclass}
+
+\newcommand{\headlinecolor}{\normalcolor}
+\LoadClass[onecolumn]{article}

--- a/example/my_report.tex
+++ b/example/my_report.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper]{article}
+\documentclass[a4paper]{example_class}
 
 \usepackage[backend=biber]{biblatex}
 \addbibresource{example/references.bib}
@@ -12,4 +12,3 @@
 \input{example/chapters/introduction}
 \printbibliography
 \end{document}
-

--- a/latex.bzl
+++ b/latex.bzl
@@ -1,5 +1,11 @@
 def _latex_pdf_impl(ctx):
     toolchain = ctx.toolchains["@bazel_latex//:latex_toolchain_type"].latexinfo
+    custom_dependencies = []
+    for srcs in ctx.attr.srcs:
+        for file in srcs.files.to_list():
+            if file.dirname not in custom_dependencies:
+                custom_dependencies.append(file.dirname)
+    custom_dependencies = ','.join(custom_dependencies)
     ctx.actions.run(
         mnemonic = "LuaLatex",
         use_default_shell_env = True,
@@ -13,6 +19,7 @@ def _latex_pdf_impl(ctx):
             ctx.label.name,
             ctx.files.main[0].path,
             ctx.outputs.out.path,
+            custom_dependencies,
         ] + ctx.attr.cmd_flags,
         inputs = depset(
             direct = ctx.files.main + ctx.files.srcs + ctx.files._latexrun,

--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-ARGS_COUNT = 9
+ARGS_COUNT = 10
 
 # Walk through all externals. If they start with the special prefix
 # texlive_{extra,texmf}__ prefix, it means they should be part of the
@@ -38,7 +38,12 @@ for external in sorted(os.listdir("external")):
     job_name,
     main_file,
     output_file,
+    dependency_list,
 ) = sys.argv[1:ARGS_COUNT]
+
+# Add custom dependencies to TEXINPUTS
+dependency_list = dependency_list.split(',')
+texinputs.extend([os.path.abspath(path) for path in dependency_list])
 
 env = dict(os.environ)
 env["OPENTYPEFONTS"] = ":".join(texinputs)
@@ -64,7 +69,7 @@ return_code = subprocess.call(
         "--latex-args=-shell-escape -jobname=" + job_name,
         "--latex-cmd=lualatex",
         "-Wall",
-        ] + sys.argv[ARGS_COUNT:] + [main_file],
+    ] + sys.argv[ARGS_COUNT:] + [main_file],
     env=env,
 )
 if return_code != 0:


### PR DESCRIPTION
Except texlive dependencies, conventionally we have to put the dependencies in the root dir only.
This CL makes subdir seperated dependencies as TEXINPUTS params.