### PR TITLE
Fix long file names

### DIFF
--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -54,6 +54,7 @@ env["TEXMF"] = os.path.abspath("texmf/texmf-dist")
 env["TEXMFCNF"] = os.path.abspath("texmf/texmf-dist/web2c")
 env["TEXMFROOT"] = os.path.abspath("texmf")
 env["TTFONTS"] = ":".join(texinputs)
+env["max_print_line"] = "480"
 
 os.mkdir("bin")
 shutil.copy(kpsewhich_file, "bin/kpsewhich")


### PR DESCRIPTION
latexrun doesn't properly parse LaTeX's output when the filename doesn't fit in a single line - see https://github.com/aclements/latexrun/issues/19. This forces it to use ~`MAX_INT` as a max line length, effectively leaving the line-wrapping job up to the terminal (which should be its responsibility, not LaTeX's), and works around this issue.~ 480 as a max line length, anything significantly longer seems to break something with `//packages:glossaries-extra`

Fixes #50