### PR TITLE
Allow spaces in jobname

### DIFF
--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -66,7 +66,7 @@ shutil.copy("texmf/texmf-dist/scripts/texlive/fmtutil.pl", "bin/mktexfmt")
 return_code = subprocess.call(
     args=[
         latexrun_file,
-        "--latex-args=-shell-escape -jobname=" + job_name,
+        "--latex-args=-shell-escape -jobname='" + job_name + "'",
         "--latex-cmd=lualatex",
         "-Wall",
     ] + sys.argv[ARGS_COUNT:] + [main_file],

--- a/run_lualatex.py
+++ b/run_lualatex.py
@@ -66,7 +66,7 @@ shutil.copy("texmf/texmf-dist/scripts/texlive/fmtutil.pl", "bin/mktexfmt")
 return_code = subprocess.call(
     args=[
         latexrun_file,
-        "--latex-args=-shell-escape -jobname='" + job_name + "'",
+        "--latex-args=-shell-escape -jobname='" + job_name.replace("'", "'\\''") + "'",
         "--latex-cmd=lualatex",
         "-Wall",
     ] + sys.argv[ARGS_COUNT:] + [main_file],


### PR DESCRIPTION
The call to latexrun inserts the job name, but doesn't do any shell escaping while passing it. Wrapping this input in single quotes keeps it from being split or otherwise processed by the next shell pass.