### PR TITLE
Add a Windows toolchain

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,6 +34,14 @@ latex_toolchain(
     platform = "x86_64-linux",
 )
 
+latex_toolchain(
+    exec_compatible_with = [
+        "@bazel_tools//platforms:windows",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    platform = "win32",
+)
+
 filegroup(
     name = "core_dependencies",
     srcs = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,9 +16,9 @@ register_toolchains(
     "//:latex_toolchain_amd64-freebsd",
     "//:latex_toolchain_x86_64-darwin",
     "//:latex_toolchain_x86_64-linux",
+    "//:latex_toolchain_win32",
 )
 
 load("@bazel_latex//:repositories.bzl", "latex_repositories")
 
 latex_repositories()
-

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -5642,12 +5642,16 @@ def latex_repositories():
         name = "texlive_%s" % path.replace("/", "__")
         http_archive(
             name = name,
-            build_file_content = """
-exports_files(
-    ["kpsewhich", "luatex", "bibtex", "biber"],
+            build_file_content = "\n".join(["""
+filegroup(
+    name = "%s_bin",
+    srcs = select({
+        "@bazel_tools//platforms:windows": ["%s.exe"],
+        "//conditions:default": ["%s"],
+    }),
     visibility = ["//visibility:public"],
 )
-""",
+""" % (bin, bin, bin) for bin in ["kpsewhich", "luatex", "bibtex", "biber"]]),
             sha256 = sha256,
             url = "https://github.com/ProdriveTechnologies/texlive-modular/releases/download/%s/texlive-%s-%s.tar.xz" % (_TEXLIVE_VERSION, _TEXLIVE_VERSION, path.replace("/", "--")),
         )
@@ -5696,4 +5700,5 @@ filegroup(
         "@bazel_latex//:latex_toolchain_amd64-freebsd",
         "@bazel_latex//:latex_toolchain_x86_64-darwin",
         "@bazel_latex//:latex_toolchain_x86_64-linux",
+        "@bazel_latex//:latex_toolchain_win32",
     )

--- a/toolchain.bzl
+++ b/toolchain.bzl
@@ -44,10 +44,10 @@ _latex_toolchain_info = rule(
 def latex_toolchain(platform, exec_compatible_with):
     _latex_toolchain_info(
         name = "latex_toolchain_info_%s" % platform,
-        kpsewhich = "@texlive_bin__%s//:kpsewhich" % platform,
-        luatex = "@texlive_bin__%s//:luatex" % platform,
-        bibtex = "@texlive_bin__%s//:bibtex" % platform,
-        biber = "@texlive_bin__%s//:biber" % platform,
+        kpsewhich = "@texlive_bin__%s//:kpsewhich_bin" % platform,
+        luatex = "@texlive_bin__%s//:luatex_bin" % platform,
+        bibtex = "@texlive_bin__%s//:bibtex_bin" % platform,
+        biber = "@texlive_bin__%s//:biber_bin" % platform,
         visibility = ["//visibility:public"],
     )
 


### PR DESCRIPTION
This needs a bit more work - at least the `BUILD` file generated for the `bin` repo needs to look for `.exe` files, and same goes when creating the toolchain. I'll try to finish that tomorrow.