### PR TITLE
Disable Windows on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
         platform:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
 
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Work for a Windows compatible toolchain is tracked in #94.