### PR TITLE
Disable Ubuntu on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
           - "example"
           - "packages"
         platform:
-          - ubuntu-latest
           - macos-latest
 
 


### PR DESCRIPTION
It's currently failing for no obvious reason, and Linux is already covered by Cirrus CI. This is just a temporary measure to unblock other PRs. (#93)