### PR TITLE
Use the external `@platforms` repo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,8 +12,8 @@ toolchain_type(
 
 latex_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:freebsd",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:freebsd",
     ],
     platform = "amd64-freebsd",
 )
@@ -21,8 +21,8 @@ latex_toolchain(
 latex_toolchain(
     name = "latex_toolchain_aarch64-darwin",
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:aarch64",
+        "@platforms//cpu:aarch64",
+        "@platforms//os:osx",
     ],
     platform = "universal-darwin",
 )
@@ -30,16 +30,16 @@ latex_toolchain(
 latex_toolchain(
     name = "latex_toolchain_x86_64-darwin",
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:osx",
     ],
     platform = "universal-darwin",
 )
 
 latex_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     platform = "x86_64-linux",
 )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -6661,6 +6661,15 @@ filegroup(
         url = "https://github.com/aclements/latexrun/archive/38ff6ec2815654513c91f64bdf2a5760c85da26e.tar.gz",
     )
 
+    http_archive(
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        ],
+        sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+    )
+
     native.register_toolchains(
         "@bazel_latex//:latex_toolchain_aarch64-darwin",
         "@bazel_latex//:latex_toolchain_amd64-freebsd",


### PR DESCRIPTION
This will be necessary with Bazel 6, and should be a no-op before that.