### PR TITLE
Actually use the Helvetica font in the helvet test.

### DIFF
--- a/packages/helvet_test.tex
+++ b/packages/helvet_test.tex
@@ -1,5 +1,7 @@
 \documentclass{report}
 \usepackage{helvet}
+\renewcommand\familydefault{\sfdefault}
+\usepackage[T1]{fontenc}
 \begin{document}
 \chapter{Chapter}
 \section{Section}


### PR DESCRIPTION
It is not enough to `\usepackage{helvet}`. One also needs to switch to sans serif font (`\renewcommand\familydefault{\sfdefault}`) and `\usepackage[T1]{fontenc}`. Otherwise the document will be rendered with the default serif font.